### PR TITLE
Remove test for string in substring using -1

### DIFF
--- a/python/notebooks/ex06_strings.ipynb
+++ b/python/notebooks/ex06_strings.ipynb
@@ -164,7 +164,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note: What is the difference between `word.find(\"i\")` and `word.find(\"i\") > -1`? What does it return if `\"i\"` is not found?"
+    "Note: What is the difference between `word.find(\"i\")` and `\"i\" in word`? What does it return if `\"i\"` is not found?"
    ]
   },
   {
@@ -296,7 +296,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/python/notebooks/solutions/ex06_strings_solutions.ipynb
+++ b/python/notebooks/solutions/ex06_strings_solutions.ipynb
@@ -324,26 +324,6 @@
     }
    ],
    "source": [
-    "for word in split_s:\n",
-    "    if word.lower().find(\"i\") > -1:\n",
-    "        print(f\"I found 'i' in {word}\")  # <-- note use of f string"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I found 'i' in I\n",
-      "I found 'i' in write\n"
-     ]
-    }
-   ],
-   "source": [
     "# NOTE: You can also use 'in' to find a sub-string in a string, as follows:\n",
     "#\n",
     "#     if \"i\" in word:\n",
@@ -352,19 +332,19 @@
     "\n",
     "for word in split_s:\n",
     "    if \"i\" in word.lower():\n",
-    "        print(f\"I found 'i' in {word}\")"
+    "        print(f\"I found 'i' in {word}\")  # <-- note use of f string"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note: What is the difference between `word.find(\"i\")` and `word.find(\"i\") > -1`? What does it return if `\"i\"` is not found?"
+    "Note: What is the difference between `word.find(\"i\")` and `\"i\" in word`? What does it return if `\"i\"` is not found?"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -383,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -395,12 +375,12 @@
     }
    ],
    "source": [
-    "print(word.find(\"t\") > -1)"
+    "print(\"t\" in word)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -417,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -429,12 +409,12 @@
     }
    ],
    "source": [
-    "print(word.find(\"i\") > -1)"
+    "print(\"i\" in word)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -463,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -503,7 +483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -512,7 +492,7 @@
        "2"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -530,7 +510,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -539,7 +519,7 @@
        "3"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -557,7 +537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -566,7 +546,7 @@
        "['Compl', 't', 'ly Diff', 'r', 'nt']"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -584,7 +564,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -610,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -620,7 +600,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-26-75ee41fbc0bf>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0msomething\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"B\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/tmp/ipykernel_7987/1880399985.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0msomething\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"B\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
       "\u001b[0;31mTypeError\u001b[0m: 'str' object does not support item assignment"
      ]
     }
@@ -655,7 +635,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The python documntation recomends against using .find to check is sub is in string. This PR changes the solution to use `in` instead, although I'm not sure if a change to the slides would also be required.