### PR TITLE
Fix two typos in numpy array exercise

### DIFF
--- a/python/notebooks/ex13_numpy_arrays.ipynb
+++ b/python/notebooks/ex13_numpy_arrays.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true,
     "pycharm": {
      "name": "#%% md\n"
     }
@@ -29,116 +28,125 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Let's create a numpy array from a list.\n",
     "\n",
-    "Create a with values 1 to 10 and assign it to the variable `x`"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "Create a list with values 1 to 10 and assign it to the variable `x`"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "x = ..."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Create a numpy integer array using `x` and print its `dtype`"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Create a numpy float array using `x` and print its `dtype`"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "Create a numpy float array using `x` and print its `dtype`"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Let's create arrays in different way.\n",
     "\n",
     "- Create an array of shape (2, 3, 4) of zeros\n",
     "- Create an array of shape (2, 3, 4) of ones.\n",
-    "- Create an array with values 0 to 999 using the `np.arrange` function."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "- Create an array with values 0 to 999 using the `np.arange` function."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "zeros = ...\n",
     "ones = ...\n",
     "arr = ..."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Let's look at indexing and slicing arrays.\n",
     "\n",
@@ -146,27 +154,28 @@
     "\n",
     "- Do you know what `a[1]` will equal? Print to see.\n",
     "- Try print `a[1:4]` to see what that equals."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "a = ..."
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "a = ..."
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Create a 2-D array from the following list and assign it to the variable `a`:\n",
     "```python\n",
@@ -182,27 +191,28 @@
     "- `a[:, 3]`\n",
     "- `a[1:4, 0:4]`\n",
     "- `a[1:, 2]`"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "a = ..."
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "a = ..."
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## 2. Interrogating and manipulating arrays\n",
     "\n",
@@ -220,27 +230,28 @@
     "- Print the shape of the array\n",
     "- Print the size of the array\n",
     "- Print and maximum and minimum of the array"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "arr = ..."
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "arr = ..."
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Let's generate new arrays by modifying our array\n",
     "\n",
@@ -250,25 +261,26 @@
     "- Print the array transposed\n",
     "- Print the array flattened to a single dimension\n",
     "- Print the array converted to floats"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## 3. Array calculation and operations\n",
     "\n",
@@ -294,28 +306,29 @@
     "- Print the arrays `b1` and `b2`\n",
     "- Print `b1 == b2`, are they the same?\n",
     "- Why do they display differently? Interrogate the `dtype` of each array to find out why"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "a = ...\n",
     "b = ..."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Let's look at array comparisons\n",
     "\n",
@@ -324,27 +337,28 @@
     "- Print two different way of expressing the condition where the array is less than 3.\n",
     "- Create a numpy condition where `arr` is less than 3 OR greater than 8.\n",
     "- Use the `where` function to create a new array where the value is `arr*5` if the above condition is `True` and `arr-5` where the condition is `False`"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "arr = ..."
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "arr = ..."
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Let's implement a mathematical function that works on arrays.\n",
     "\n",
@@ -356,28 +370,29 @@
     "\n",
     "- Test your function on `u = [[4, 5, 6], [2, 3, 4]]` and `v = [[2, 2, 2], [1, 1, 1]]` values.\n",
     "- Test your function on `u = [[4, 5, 0.01], [2, 3, 4]]` and `v = [[2, 2, 0.03], [1, 1, 1]]` values. Does your default minimum magnitude get used?"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "def calc_magnitude(u, v):\n",
     "    ..."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## 4. Working with missing values\n",
     "\n",
@@ -394,52 +409,54 @@
     "### Let's create a masked array and play with it\n",
     "\n",
     "Import the `numpy.ma` module as `MA`"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Create a masked array from a list of values (0 to 9) with a `fill_value` of -999 and assign it to the variable `marr`\n",
     "\n",
     "- Print the array to view its values. Print the `fill_value` attribute.\n",
     "- Mask the third value in the array using `MA.masked`, print the array to view how it has changed.\n",
     "- Print the mask associated with the array (i.e. `marr.mask`)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
-   "source": [
-    "marr = ..."
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "marr = ..."
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Create a new masked array called `narr` that is equal to `marr` where `marr` is less than 7 and masked otherwise.\n",
     "\n",
@@ -447,29 +464,30 @@
     "- Print its missing value (i.e. `narr.fill_value`)\n",
     "- Print an array that converts `narr` so that the missing values are represented by the missing value (i.e. `MA.filled`). Assign it to `farr`\n",
     "- What is the type of the `farr`"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "narr = ...\n",
     "\n",
     "farr = ..."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Let's create a mask that is smaller than the overall array\n",
     "\n",
@@ -479,14 +497,20 @@
     "- Print `m3` multiplied by 100\n",
     "- Subtract `m3` by a normal numpy array of `ones` that is the same shape as `m3` and assign it to he variable `m4`, print `m4`\n",
     "- Is `m4` a normal array or masked array?"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "m1 = ...\n",
@@ -496,34 +520,28 @@
     "m3 = ...\n",
     "\n",
     "m4 = ..."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 + Jaspy",
    "language": "python",
-   "name": "python3"
+   "name": "jaspy"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/python/notebooks/solutions/ex13_numpy_arrays_solutions.ipynb
+++ b/python/notebooks/solutions/ex13_numpy_arrays_solutions.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true,
     "pycharm": {
      "name": "#%% md\n"
     }
@@ -29,58 +28,71 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "outputs": [],
-   "source": [
-    "import numpy as np"
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Let's create a numpy array from a list.\n",
     "\n",
-    "Create a with values 1 to 10 and assign it to the variable `x`"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "Create a list with values 1 to 10 and assign it to the variable `x`"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "outputs": [],
-   "source": [
-    "x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
-   ],
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Create a numpy integer array using `x` and print its `dtype`"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "dtype('int64')"
+      "text/plain": [
+       "dtype('int64')"
+      ]
      },
      "execution_count": 3,
      "metadata": {},
@@ -89,33 +101,37 @@
    ],
    "source": [
     "np.array(x, int).dtype"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Create a numpy float array using `x` and print its `dtype`"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "Create a numpy float array using `x` and print its `dtype`"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "dtype('float64')"
+      "text/plain": [
+       "dtype('float64')"
+      ]
      },
      "execution_count": 4,
      "metadata": {},
@@ -124,30 +140,31 @@
    ],
    "source": [
     "np.array(x, float).dtype"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Let's create arrays in different way.\n",
     "\n",
     "- Create an array of shape (2, 3, 4) of zeros and print.\n",
     "- Create an array of shape (2, 3, 4) of ones and print.\n",
-    "- Create an array with values 0 to 999 using the `np.arrange` function and print."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "- Create an array with values 0 to 999 using the `np.arange` function and print."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -235,16 +252,11 @@
     "\n",
     "arr = np.arange(1000)\n",
     "print(arr)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Let's look at indexing and slicing arrays.\n",
     "\n",
@@ -252,14 +264,20 @@
     "\n",
     "- Do you know what `a[1]` will equal? Print to see.\n",
     "- Try print `a[1:4]` to see what that equals."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -274,16 +292,11 @@
     "a = np.array([2, 3.2, 5.5, -6.4, -2.2, 2.4])\n",
     "print(a[1])\n",
     "print(a[1:4])"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Create a 2-D array from the following list and assign it to the variable `a`:\n",
     "```python\n",
@@ -299,14 +312,20 @@
     "- `a[:, 3]`\n",
     "- `a[1:4, 0:4]`\n",
     "- `a[1:, 2]`"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -332,16 +351,11 @@
     "print(a[:3])\n",
     "print(a[1:4, 0:4])\n",
     "print(a[1:, 2])"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## 2. Interrogating and manipulating arrays\n",
     "\n",
@@ -359,14 +373,20 @@
     "- Print the shape of the array\n",
     "- Print the size of the array\n",
     "- Print and maximum and minimum of the array"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -388,16 +408,11 @@
     "print(arr.shape)\n",
     "print(arr.size)\n",
     "print(f\"max: {arr.max()}, min: {arr.min()}\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Let's generate new arrays by modifying our array\n",
     "\n",
@@ -407,14 +422,20 @@
     "- Print the array transposed\n",
     "- Print the array flattened to a single dimension\n",
     "- Print the array converted to floats"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -444,16 +465,11 @@
     "print(\"transpose\\n\", arr.transpose())\n",
     "print(\"flatten\\n\", arr.flatten())\n",
     "print(\"float\\n \", arr.astype(float))"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## 3. Array calculation and operations\n",
     "\n",
@@ -479,14 +495,20 @@
     "- Print the arrays `b1` and `b2`\n",
     "- Print `b1 == b2`, are they the same?\n",
     "- Why do they display differently? Interrogate the `dtype` of each array to find out why"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -517,16 +539,11 @@
     "print(b2)\n",
     "print(b1 == b2)\n",
     "print(f\"b1: {b1.dtype}, b2: {b2.dtype}\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Let's look at array comparisons\n",
     "\n",
@@ -535,14 +552,20 @@
     "- Print two different way of expressing the condition where the array is less than 3.\n",
     "- Create a numpy condition where `arr` is less than 3 OR greater than 8.\n",
     "- Use the `where` function to create a new array where the value is `arr*5` if the above condition is `True` and `arr-5` where the condition is `False`"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -563,16 +586,11 @@
     "condition = np.logical_or(arr < 3, arr > 8)\n",
     "new_arr = np.where(condition, arr*5, arr-5)\n",
     "print(new_arr)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Let's implement a mathematical function that works on arrays.\n",
     "\n",
@@ -584,14 +602,20 @@
     "\n",
     "- Test your function on `u = [[4, 5, 6], [2, 3, 4]]` and `v = [[2, 2, 2], [1, 1, 1]]` values.\n",
     "- Test your function on `u = [[4, 5, 0.01], [2, 3, 4]]` and `v = [[2, 2, 0.03], [1, 1, 1]]` values. Does your default minimum magnitude get used?"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -617,16 +641,11 @@
     "u = [[4, 5, 0.01], [2, 3, 4]]\n",
     "v = [[2, 2, 0.03], [1, 1, 1]]\n",
     "print(calc_magnitude(u, v))"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## 4. Working with missing values\n",
     "\n",
@@ -643,41 +662,48 @@
     "### Let's create a masked array and play with it\n",
     "\n",
     "Import the `numpy.ma` module as `MA`"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "outputs": [],
-   "source": [
-    "import numpy.ma as MA"
-   ],
+   "execution_count": 17,
    "metadata": {
     "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy.ma as MA"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Create a masked array from a list of values (0 to 9) with a `fill_value` of -999 and assign it to the variable `marr`\n",
     "\n",
     "- Print the array to view its values. Print the `fill_value` attribute.\n",
     "- Mask the third value in the array using `MA.masked`, print the array to view how it has changed.\n",
     "- Print the mask associated with the array (i.e. `marr.mask`)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -697,16 +723,11 @@
     "print(marr)\n",
     "\n",
     "print(marr.mask)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Create a new masked array called `narr` that is equal to `marr` where `marr` is less than 7 and masked otherwise.\n",
     "\n",
@@ -714,14 +735,20 @@
     "- Print its missing value (i.e. `narr.fill_value`)\n",
     "- Print an array that converts `narr` so that the missing values are represented by the missing value (i.e. `MA.filled`). Assign it to `farr`\n",
     "- What is the type of the `farr`"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -741,16 +768,11 @@
     "\n",
     "farr = MA.filled(narr)\n",
     "print(farr, type(farr))"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Let's create a mask that is smaller than the overall array\n",
     "\n",
@@ -760,14 +782,20 @@
     "- Print `m3` multiplied by 100\n",
     "- Subtract `m3` by a normal numpy array of `ones` that is the same shape as `m3` and assign it to he variable `m4`, print `m4`\n",
     "- Is `m4` a normal array or masked array?"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -798,34 +826,28 @@
     "\n",
     "m4 = np.subtract(m3, np.ones(m3.shape))\n",
     "print(m4, type(m4))"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 + Jaspy",
    "language": "python",
-   "name": "python3"
+   "name": "jaspy"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
create a -> create a list (second cell).
arrange -> arange ("Lets create arrays in a different way).

Jupyter also fiddled with the formatting, apologies.